### PR TITLE
Fix typos Update nexus-memory-checking.mdx

### DIFF
--- a/pages/specs/nexus-memory-checking.mdx
+++ b/pages/specs/nexus-memory-checking.mdx
@@ -9,11 +9,11 @@ image: "/nexus-head.png"
 
 Since the external memory used by the Nexus Virtual Machine is assumed to be untrusted, the Nexus zkVM must ensure read-write consistency throughout the execution of a program. Informally, this requires that reading the contents of any cell of the memory should always return the value last written to that cell.
 
-In order to enforce the consistency of read-write operations into the memory, the Nexus zkVM currently uses Merkle Trees [[M87](#references)] together with the Poseidon hash function [[GKR21](#references)]. In this method, the contents of the memory are first associated with leaves of a Merkle tree and then Merkle-hashed into a Merkle root. The latter Merkle root serves as a binding commitment to the memory and needs to be updated whenever the contents of the memory change.
+In order to enforce the consistency of read-write operations in the memory, the Nexus zkVM currently uses Merkle Trees [[M87](#references)] together with the Poseidon hash function [[GKR21](#references)]. In this method, the contents of the memory are first associated with leaves of a Merkle tree and then Merkle-hashed into a Merkle root. The latter Merkle root serves as a binding commitment to the memory and needs to be updated whenever the contents of the memory change.
 
 ### Merkle Tree Setup
 
-In the current version of Nexus VM, the memory size is set to $\mathbf{2^{22}}$ bytes. Hence, we associate leafs to 256-bit-long strings (i.e., 32 bytes) and then use a Merkle binary tree with 17 levels to describe its contents, as in the figure below.
+In the current version of Nexus VM, the memory size is set to $\mathbf{2^{22}}$ bytes. Hence, we associate leaves to 256-bit-long strings (i.e., 32 bytes) and then use a Merkle binary tree with 17 levels to describe its contents, as in the figure below.
 
 ![merkle-hash-tree](/images/merkle-hash-tree.svg)
 


### PR DESCRIPTION
Two small but important language issues in the documentation that could impact readability and professionalism:  

1. **"leafs" → "leaves"**  
   In the *Merkle Tree Setup* section, the plural of "leaf" was incorrectly written as "leafs." This has been corrected to "leaves," which is grammatically correct and standard English usage.  

   Original:  
   > Hence, we associate leafs to 256-bit-long strings (i.e., 32 bytes)...  

   Fixed:  
   > Hence, we associate leaves to 256-bit-long strings (i.e., 32 bytes)...  

2. **"into the memory" → "in the memory"**  
   In the *Nexus zkVM Memory Checking* section, the phrase "into the memory" was used, which is less natural in this context. Replacing it with "in the memory" ensures smoother readability and correctness in technical writing.  

   Original:  
   > In order to enforce the consistency of read-write operations into the memory...  

   Fixed:  
   > In order to enforce the consistency of read-write operations in the memory...  

These corrections enhance the clarity and professionalism of the documentation, making it easier for developers to understand and engage with the content.