### PR TITLE
Fix typo

### DIFF
--- a/pages/zkvm/sdk-quick-start.mdx
+++ b/pages/zkvm/sdk-quick-start.mdx
@@ -110,7 +110,7 @@ fn main() {
     let pp: PP = PP::generate().expect("failed to generate parameters");
 
     let mut opts = CompileOpts::new(PACKAGE);
-    opts.set_memlimit(8); // use an 8mb memory
+    opts.set_memlimit(8); // use a 8mb memory
 
     println!("Compiling guest program...");
     let prover: Nova<Local> = Nova::compile(&opts).expect("failed to compile guest program");


### PR DESCRIPTION
This pull request corrects the use of the indefinite article in the `sdk-quick-start.mdx` file.  

**Changes made:**  
- Corrected "use an 8mb memory" to "use a 8mb memory" as the word "8mb" starts with a consonant sound.  

This fix improves the grammatical accuracy of the documentation.  
