### PR TITLE
docs: fix numbering inconsistency in guide Update cli-quick-start.mdx

### DIFF
--- a/pages/zkvm/cli-quick-start.mdx
+++ b/pages/zkvm/cli-quick-start.mdx
@@ -87,7 +87,7 @@ You should see the program print:
 "Hello, World!"
 ```
 
-### 3. Prove your program
+### 4. Prove your program
 
 Generate a zero-knowledge proof for your Rust program using the Nexus zkVM.
 
@@ -97,7 +97,7 @@ cargo nexus prove
 
 This will generate a proof, and store it in `./nexus-proof`.
 
-### 4. Verify your proof
+### 5. Verify your proof
 
 Finally, load and verify the proof:
 


### PR DESCRIPTION
<img width="976" alt="Снимок экрана 2024-12-12 в 15 04 54" src="https://github.com/user-attachments/assets/df7a265b-8457-447c-883b-2eb220a638e1" />

This update addresses a minor numbering inconsistency in the CLI Quick Start guide. The section "Prove your program" and "Verify your proof" were both labeled as step 3. The correct numbering has been applied, renaming the latter to step 4.  

Fixed.