### PR TITLE
Update nexus-vm.mdx

### DIFF
--- a/pages/specs/nexus-vm.mdx
+++ b/pages/specs/nexus-vm.mdx
@@ -9,7 +9,7 @@ import { Callout } from 'nextra/components'
 
 ## Nexus Virtual Machine
 
-The Nexus Virtual Machine (Nexus VM or NVM) is a reduced instruction set computer (RISC) with a byte-addressable random-access memory and a private input tape. This virtual machine abstraction is comparable to others used in the zero-knowledge research space, such as the [TinyRAM architecture specification][TinyRAM]. The advantage of using such random-access machines is that they abstract away details of the underlying hardware or operating system and provide a convenient tool for generating claims and proofs about the correctness of a computation.
+The Nexus Virtual Machine (Nexus VM or NVM) is a reduced instruction set computer (RISC) with a byte-addressable random-access memory and a private input tape. This virtual machine abstraction is comparable to others used in the zero-knowledge research space, such as the [TinyRAM architecture specification][TinyRAM]. The advantage of using such random-access machines is that they abstract away the details of the underlying hardware or operating system and provide a convenient tool for generating claims and proofs about the correctness of a computation.
 
 <Callout type="info" emoji="ℹ️">
   The NVM architecture has not yet stabilized. The following specification describes the architecture as of the Nexus zkVM 0.2.0 release.


### PR DESCRIPTION
Changes Made:

Old word: "away details"

New word: "away the details"

This small grammatical fix improves readability of the Nexus VM documentation.
